### PR TITLE
fix(bookmark) - 북마크 복구 관련 에러 수정

### DIFF
--- a/src/main/java/com/back/pinco/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/back/pinco/domain/bookmark/repository/BookmarkRepository.java
@@ -19,6 +19,15 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findByUserAndDeletedFalse(User user);
 
     /**
+     * 특정 사용자가 특정 핀을 북마크했는지 확인 (삭제 여부와 관계없이)
+     *
+     * @param user 사용자 엔티티
+     * @param pin 핀 엔티티
+     * @return 북마크가 존재하면 Optional에 담아 반환, 없으면 빈 Optional 반환
+     */
+    Optional<Bookmark> findByUserAndPin(User user, Pin pin);
+
+    /**
      * 특정 사용자가 특정 핀을 이미 북마크했는지 확인 (삭제되지 않은 것만)
      *
      * @param user 사용자 엔티티


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
북마크 취소했던 핀을 다시 북마크 할 시 생기는 에러 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
문제 발생 상황: 북마크 취소했던 핀을 재 북마크 할 시 ErrorCode.BOOKMARK_CREATE_FAILED 발생

문제 발생 이유:
1. 기존 코드의 경우 북마크 생성 시 findByUserAndPinAndDeletedFalse를 사용하여 북마크 객체를 조회하였음.
2. 하지만 삭제된 전적이 있던 북마크인 경우 deleted 필드가 true로 되어 있어 null을 반환하게 됨.
3. 이 후 null 값을 받은 서비스 단에서 새로운 북마크로 착각하고 새로운 북마크 객체를 생성.
4. 이렇게 생성된 북마크 객체는 user_id와 pin_id 조합으로 유일성 제약 조건이 걸려있기에 유일성 제약 조건 위반 에러를 발생시키게 됨.

해결 방안: 
1. 북마크 생성 시 deleted 상태를 고려하지 않고 북마크를 조회
2. 북마크 조회 후 북마크가 이미 존재하고, deleted = true인 경우 restore처리

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
