### PR TITLE
fix(auth): 로그인/로그아웃 이력이 없을 때, 모든 핀 조회했을 시 2013 에러코드가 발생하던 사항을 수정

### DIFF
--- a/src/main/java/com/back/pinco/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/pinco/global/security/CustomAuthenticationFilter.java
@@ -40,8 +40,15 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         final String uri = req.getRequestURI();
+        final String method = req.getMethod();
 
-        // /api/* 가 아니거나 공개 경로면 바로 통과 (여기서 난 예외는 전역 핸들러가 처리)
+        // /api/pins 와 /api/pins/** 둘 다 허용
+        if (method.equals("GET") && (uri.equals("/api/pins") || uri.startsWith("/api/pins/"))) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        // /api/* 가 아니거나 공개 경로(join, login)면 바로 통과
         if (!uri.startsWith("/api/") || PERMIT_PATHS.stream().anyMatch(uri::equals)) {
             chain.doFilter(req, res);
             return;


### PR DESCRIPTION
버그 내용
홈페이지 첫 접속 시에는 토큰과 API 키도 없음. 이 상태에서 'api/pins/all'을 호출하면
SecurityConfig가 GET /api/pins/**에 대한 permitAll() 규칙을 적용하기 전에
CustomAuthenticationFilter가 접근을 차단해버림.

해결법
CustomAuthenticationFilter 규칙 수정
SecurityConfig처럼 GET /api/pins/** 요청을 허용하게 수정.
